### PR TITLE
Add session id and info interface with tag

### DIFF
--- a/src/CLMS/CLMS/urls.py
+++ b/src/CLMS/CLMS/urls.py
@@ -34,5 +34,7 @@ urlpatterns = [
     url(r'^index/$', views.index, name='index4test'),
     url(r'^login/$', views.login, name='Login'),
     url(r'^register/$', views.register, name='Register'),
+    url(r'^infocheck/$', views.userInfoSearch, name='UserInfoSearch'),
+    url(r'^infocheck/inforenew/$', views.userInfoAlter, name='InfoRenew'),
     # url(r'^wechat$', views.wechat, name='Wechat')
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/src/CLMS/Main/models.py
+++ b/src/CLMS/Main/models.py
@@ -8,7 +8,7 @@ import os
 
 
 def make_thumb(path, thumb_path, size=(160, 120)):
-    image = skimage.io.imread(path)
+    image = skimage.io.imread(path) 
     height, width = image.shape[0], image.shape[1]
 
     thumb = image
@@ -136,13 +136,38 @@ class Lecture(models.Model):
 
 
 class User(models.Model):
+    
+    '''tagInterest = (
+        ('Science',(
+            ('Program','Programming'),
+            ('HardWare','Hardware'),
+            ('Arch','Building'),
+            )
+        ),
+        ('Humanity',(
+            ('Poem','Poems'),
+            ('Comp','Composition'),
+            )
+        ),
+    )'''
+
     username = models.CharField(max_length=30)
     password = models.CharField(max_length=30)
 
     # Undergraduate or graduate student
     stuType = models.CharField(max_length=30)
-    grade = models.IntegerField(default=0)
+    infoUser = models.CharField(max_length=30)
+    infoPasswd = models.CharField(max_length=30)
+    infoValid = models.BooleanField(default=False)
+    email = models.EmailField(max_length=40)
+    emailValid = models.BooleanField(default=False)
+    stuName = models.CharField(max_length=15)
+    stuNo = models.IntegerField(default=2000000000)
+    grade = models.CharField(max_length=20,default='-------')
     interestTag = models.ManyToManyField(Tag)   # for recommendation
-
+    
+    
     def __unicode__(self):
         return self.username
+    
+    

--- a/src/CLMS/Main/views.py
+++ b/src/CLMS/Main/views.py
@@ -251,7 +251,40 @@ def register(request):
     return HttpResponse('Not valid')
 # test login and logout
 
+def userInfoSearch(request):
+    if 'user_id' not in request.session:
+        return HttpResponse("Error! Please login before you search for personal info.")
+    else:
+        userinfo = User.objects.get(username=request.session['user_id'])
+        return render(request,'userinfo.html',{'userinfo':userinfo})
 
+def userInfoAlter(request):
+    if 'user_id' not in request.session:
+        return HttpResponse("Error! Please login before you alter your personal info.")
+    else:
+        Method = request.method
+        userinfo = User.objects.get(username=request.session['user_id'])
+        print('success')
+        if Method == 'POST':
+            userinfo.email = request.POST.get('email')
+            userinfo.stuNo = request.POST.get('stuNo')
+            userinfo.stuName = request.POST.get('stuName')
+            userinfo.infoUser = request.POST.get('infoUser')
+            userinfo.infoPasswd = request.POST.get('infoPasswd')
+            userinfo.grade = request.POST.get('grade')
+            userinfo.save()
+            previousInterest = userinfo.interestTag.all()
+            for i in previousInterest:
+                userinfo.interestTag.remove(i)
+            for i in request.POST.getlist('interestTag'):
+                p = Tag(name=i)
+                p.save()
+                userinfo.interestTag.add(p)
+            userinfo.save()
+            return HttpResponse("Your information has been saved.")
+        else:
+            return render_to_response('inforenew.html',{'userinfo':userinfo})
+            
 def index(request):
     username = request.COOKIES.get('cookie_username', '')
     return render_to_response('index4test.html', {'username': username})

--- a/src/CLMS/Main/views.py
+++ b/src/CLMS/Main/views.py
@@ -213,6 +213,8 @@ def login(request):
         if uf.is_valid():
             username = uf.cleaned_data['username']
             password = uf.cleaned_data['password']
+            if 'user_id' in request.session:
+                return HttpResponse("You've logged in, please do not loggin twice.")
             userPassJudge = User.objects.filter(
                 username__exact=username, password__exact=password)
             print(username)
@@ -220,6 +222,7 @@ def login(request):
             if userPassJudge:
                 response = HttpResponse('Success')
                 response.set_cookie('cookie_username', username, 3600)
+                request.session['user_id'] = username
                 return response
             else:
                 return HttpResponse('No username or valid one')
@@ -258,6 +261,10 @@ def logout(request):
     response = HttpResponse(
         'logout!<br><a href="127.0.0.1:8000/regist>register</a>"')
     response.delete_cookie('cookie_username')
+    try:
+        del request.session['user_id']
+    except KeyError:
+        pass
     return response
 
 

--- a/src/CLMS/Main/views.py
+++ b/src/CLMS/Main/views.py
@@ -277,8 +277,12 @@ def userInfoAlter(request):
             for i in previousInterest:
                 userinfo.interestTag.remove(i)
             for i in request.POST.getlist('interestTag'):
-                p = Tag(name=i)
-                p.save()
+                find_i = Tag.objects.filter(name=i)
+                if len(find_i) == 0:
+                    p = Tag(name=i)
+                    p.save()
+                else:
+                    p = find_i[0]
                 userinfo.interestTag.add(p)
             userinfo.save()
             return HttpResponse("Your information has been saved.")

--- a/src/CLMS/templates/example/userinfo.html
+++ b/src/CLMS/templates/example/userinfo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PersonalInfo</title>
+</head>
+<body>
+Welcome {{ userinfo.username }}!<br />
+用户名 {{ userinfo.username }}<br />
+邮箱 {{ userinfo.email }}<br />
+是否验证 {{ username }}<br />
+真实姓名 {{ userinfo.stuName }}<br />
+年级 {{ userinfo.grade }}<br />
+学号 {{ userinfo.stuNo }}<br />
+info用户名 {{ userinfo.infoUser }}<br />
+验证 {{ username }}<br />
+Tags {{ userinfo.interestTag }}<br />
+
+
+<br>
+<a href="http://127.0.0.1:8000/inforenew">信息修改</a>
+<br>
+</body>
+</html>

--- a/src/CLMS/templates/example/userinfo_renew.html
+++ b/src/CLMS/templates/example/userinfo_renew.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PersonalInfo</title>
+</head>
+<body>
+Welcome {{ userinfo.username }}!<br />
+用户名 {{ userinfo.username }}<br />
+邮箱  <input type="text" name="email" value=userinfo.email/> <br />
+是否验证 {{ username }}<br />
+真实姓名  <input type="text" name="stuName" value=userinfo.stuName /> <br />
+  <form>
+年级<select name="grade">
+<option value="under_1">本科一年级</option>
+<option value="under_2">本科二年级</option>
+<option value="under_3">本科三年级</option>
+<option value="under_4">本科四年级</option>
+<option value="under_5">本科五年级及以上</option>
+<option value="grad_1">研究生一年级</option>
+<option value="grad_2">研究生二年级</option>
+<option value="grad_3">研究生三年级及以上</option>
+</select>
+</form>
+ <br />
+学号  <input type="text" name="stuNo" value=userinfo.stuNo/> <br />
+info用户名  <input type="text" name="infoUser" value=userinfo.infoUser/> <br />
+验证 {{ username }}<br />
+Tags 科学：<input type="checkbox" name="favor" value="science">
+文学：<input type="checkbox" name="favor" value="human">
+<br />
+
+
+<br>
+<a href="http://127.0.0.1:8000/inforenew">信息修改</a>
+<br>
+</body>
+</html>

--- a/src/CLMS/templates/inforenew.html
+++ b/src/CLMS/templates/inforenew.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PersonalInfo</title>
+</head>
+<body>
+Welcome {{ userinfo.username }}!<br />
+<form method = 'POST'>
+用户名 {{ userinfo.username }}<br />
+邮箱  <input type="text" name="email" value= {{ userinfo.email }} > <br />
+真实姓名  <input type="text" name="stuName" value={{ userinfo.stuName}} > <br />
+年级<select name="grade">
+<option value="本科一年级">本科一年级</option>
+<option value="本科二年级">本科二年级</option>
+<option value="本科三年级">本科三年级</option>
+<option value="本科四年级">本科四年级</option>
+<option value="本科五年级及以上">本科五年级及以上</option>
+<option value="研究生一年级">研究生一年级</option>
+<option value="研究生二年级">研究生二年级</option>
+<option value="研究生三年级及以上">研究生三年级及以上</option>
+</select>
+<br />
+学号  <input type="text" name="stuNo" value={{ userinfo.stuNo}}> <br />
+info用户名  <input type="text" name="infoUser" value={{ userinfo.infoUser}}> <br />
+info密码	  <input type="password" name="infoPasswd" value={{ userinfo.infoPasswd}}> <br />
+Tags 
+ <br />理科：<input type="checkbox" name="interestTag" value="science">
+人文：<input type="checkbox" name="interestTag" value="human">
+工程：<input type="checkbox" name="interestTag" value="engineer">
+
+<br>
+ <input type="submit" value="submit" />
+<br>
+</form>
+</body>
+</html>

--- a/src/CLMS/templates/userinfo.html
+++ b/src/CLMS/templates/userinfo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>PersonalInfo</title>
+</head>
+<body>
+<form method='POST'>
+Welcome {{ userinfo.username }}!<br />
+用户名 {{ userinfo.username }}<br />
+邮箱 {{ userinfo.email }}<br />
+是否验证 {{ username }}<br />
+真实姓名 {{ userinfo.stuName }}<br />
+年级 {{ userinfo.grade }}<br />
+学号 {{ userinfo.stuNo }}<br />
+info用户名 {{ userinfo.infoUser }}<br />
+验证 {{ username }}<br />
+Tags {{ userinfo.interestTag }}<br />
+</form>
+
+<br>
+<a href="inforenew">信息修改</a>
+<br>
+</body>
+</html>


### PR DESCRIPTION
* 增加了sessionID
* 增加了用户的信息显示页面（现在html是白板），并且可以对于部分信息进行修改，之后如果有时间会加上邮箱认证和info帐号认证这一块
* 在用户页中增加了tag，现在可以直接在Tag类中进行竞赛讲座的匹配